### PR TITLE
Feat/flip cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,10 +25,11 @@ export default async function Home() {
       content,
     };
   });
+  const startIndex = Math.floor(Math.random() * cards.length);
 
   return (
     <main className="overflow-hidden w-full h-full">
-      <Card cards={cards} />
+      <Card cards={cards} startIndex={startIndex} />
     </main>
   );
 }

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -9,33 +9,54 @@ type Props = {
 
 export default function Card({ cards }: Props) {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [currentIndex2, setCurrentIndex2] = useState(1);
-  const [rotationAngle, setRotationAngle] = useState(0);
+  // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
+  const [rotationAngles, setRotationAngles] = useState<number[]>(() =>
+    Array.from({ length: cards.length }, (_, i) => (i === 0 ? 0 : 180))
+  );
   const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
     const cardWidth = event.currentTarget.offsetWidth;
-    event.clientX > cardWidth / 2
-      ? setRotationAngle((prevAngle) => prevAngle + 180)
-      : setRotationAngle((prevAngle) => prevAngle - 180);
-    setCurrentIndex((prevIndex) => prevIndex + 2);
-    setCurrentIndex2((prevIndex) => prevIndex + 2);
+    const newAngles = [...rotationAngles];
+
+    if (event.clientX > cardWidth / 2) {
+      // 화면 우측 클릭
+      if (currentIndex === cards.length - 1) return;
+      newAngles[currentIndex] += 180;
+      newAngles[currentIndex + 1] += 180;
+      setCurrentIndex((prevIndex) => prevIndex + 1);
+    } else {
+      // 화면 좌측 클릭
+      if (currentIndex === 0) return;
+      newAngles[currentIndex] -= 180;
+      newAngles[currentIndex - 1] -= 180;
+      setCurrentIndex((prevIndex) => prevIndex - 1);
+    }
+
+    setRotationAngles(newAngles);
   };
 
   return (
-    <div className="w-full h-full [perspective:1000px]" onClick={handleFlip}>
-      <div className="flex justify-center items-center w-full h-full transform transition-transform duration-700 ease-in-out [perspective:1000px]">
-        <div
-          className="absolute w-1/2vh h-1/2vh bg-red-100 text-white flex items-center justify-center [backface-visibility:hidden] transform transition-transform duration-700 ease-in-out"
-          style={{ transform: `rotateY(${rotationAngle}deg)` }}
-        >
-          <img src={cards[currentIndex].content} />
-        </div>
-        <div
-          className="absolute w-1/2vh h-1/2vh bg-blue-100 text-white flex items-center justify-center [backface-visibility:hidden] transform transition-transform duration-700 ease-in-out"
-          style={{ transform: `rotateY(${rotationAngle + 180}deg)` }}
-        >
-          <div>{cards[currentIndex2].content}</div>
-        </div>
-      </div>
+    <div
+      className="flex justify-center items-center w-full h-full [perspective:2000px]"
+      onClick={handleFlip}
+    >
+      {cards.map((card, index) => {
+        const rotationAngle = rotationAngles[index];
+
+        return (
+          <div
+            key={card.id}
+            className="absolute w-1/2vh h-1/2vh bg-red-100 text-white flex items-center justify-center [backface-visibility:hidden] transform transition-transform duration-1000 ease-in-out"
+            style={{ transform: `rotateY(${rotationAngle}deg)` }}
+          >
+            {/* 카드 타입에 따라 조건부 렌더링 */}
+            {card.type === "text" ? (
+              <div>{card.content}</div>
+            ) : (
+              <img src={card.content} />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -5,13 +5,14 @@ import { CardType } from "@/app/page";
 
 type Props = {
   cards: CardType[];
+  startIndex: number;
 };
 
-export default function Card({ cards }: Props) {
-  const [currentIndex, setCurrentIndex] = useState(0);
+export default function Card({ cards, startIndex }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(startIndex);
   // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
   const [rotationAngles, setRotationAngles] = useState<number[]>(() =>
-    Array.from({ length: cards.length }, (_, i) => (i === 0 ? 0 : 180))
+    Array.from({ length: cards.length }, (_, i) => (i === startIndex ? 0 : 180))
   );
   const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
     const cardWidth = event.currentTarget.offsetWidth;


### PR DESCRIPTION
# 작업내용
- 카드 수만큼 div를 렌더링 해두고, flipping에 따라 해당 인덱스의 카드만 앞면으로 회전하게끔 구현(backface-visibility css 속성 이용)
- 메인 컴포넌트에서 랜덤으로 starting index를 전달하게끔 수정

# TODO
- 텍스트 부분을 plain text에서 code block으로 수정해야 함