### PR TITLE
Fix/random start

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,8 @@ export default async function Home() {
       content,
     };
   });
-  const startIndex = Math.floor(Math.random() * cards.length);
+  let startIndex = Math.floor(Math.random() * cards.length);
+  console.log(startIndex);
 
   return (
     <main className="overflow-hidden w-full h-full">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,8 @@
  * Main page of the app.
  */
 
-import Card from "@/components/Card";
+// import Card from "@/components/Card";
+import RandomWrapper from "@/components/RandomWrapper";
 import { fetchCards } from "@/lib/fetchCards";
 
 export type CardType = {
@@ -25,12 +26,10 @@ export default async function Home() {
       content,
     };
   });
-  let startIndex = Math.floor(Math.random() * cards.length);
-  console.log(startIndex);
 
   return (
     <main className="overflow-hidden w-full h-full">
-      <Card cards={cards} startIndex={startIndex} />
+      <RandomWrapper cards={cards} />
     </main>
   );
 }

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -9,6 +9,7 @@ type Props = {
 };
 
 export default function Card({ cards, startIndex }: Props) {
+  console.log(startIndex);
   const [currentIndex, setCurrentIndex] = useState(startIndex);
   // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
   const [rotationAngles, setRotationAngles] = useState<number[]>(() =>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -9,7 +9,6 @@ type Props = {
 };
 
 export default function Card({ cards, startIndex }: Props) {
-  console.log(startIndex);
   const [currentIndex, setCurrentIndex] = useState(startIndex);
   // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
   const [rotationAngles, setRotationAngles] = useState<number[]>(() =>

--- a/src/components/RandomWrapper/index.tsx
+++ b/src/components/RandomWrapper/index.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Card from "@/components/Card";
+import { CardType } from "@/app/page";
+
+type Props = {
+  cards: CardType[];
+};
+
+export default function RandomWrapper({ cards }: Props) {
+  const [startIndex, setStartIndex] = useState<number | null>(null);
+
+  // 클라이언트 사이드에서 랜덤한 인덱스 설정 (서버 캐싱 방지)
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * cards.length);
+    setStartIndex(randomIndex);
+  }, [cards.length]);
+
+  // Fallback UI
+  if (startIndex === null) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      <Card cards={cards} startIndex={startIndex} />
+    </>
+  );
+}


### PR DESCRIPTION
# 작업 내용
- `startIndex`가 배포 서버에서는 새로고침 시 랜덤한 값으로 초기화되지 않는 것을 확인함. 이는 Vercel에서 서버 컴포넌트에 대해 자동으로 캐싱을 지원하기 때문.
- 캐싱 설정을 변경할 수도 있지만, `startIndex` 하나를 위해서 이미지나 웹폰트의 캐싱을 포기하기보다, 이를 CSR로 돌리는 것이 맞다고 판단. `useEffect`를 사용하여 렌더링 시에 항상 랜덤한 startIndex를 받게끔 설정.
- 다만 Card Component에 직접 주입하려니, useEffect가 currentIndex의 의존성을 받으면서 카드를 뒤집을 때 예상치 못한 side effect가 생기는 것 확인함. 따라서 RandomWrapper(CSR) 따로 만들어 `startIndex` 생성 액션이 카드 로직과 분리되게끔 함.