### PR TITLE
feat: Add ProgressBar

### DIFF
--- a/src/components/Caption/index.tsx
+++ b/src/components/Caption/index.tsx
@@ -30,7 +30,7 @@ export default function Caption({ cards, currentIndex }: Props) {
     cards.length;
 
   return (
-    <div className="flex justify-center mt-2 mb-10 text-sm font-medium whitespace-pre">
+    <div className="flex justify-center mt-2 text-sm font-medium whitespace-pre">
       {caption}
     </div>
   );

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -49,7 +49,7 @@ export default function Card({ cards, startIndex }: Props) {
           return (
             <div
               key={card.id}
-              className="absolute w-3/4vh h-3/4vh bg-white text-black shadow-lg [backface-visibility:hidden] transform transition-transform duration-1000 ease-in-out"
+              className="absolute w-3/4vh h-3/4vh bg-white text-black shadow-lg [backface-visibility:hidden] transform transition-transform duration-1800 ease-in-out"
               style={{ transform: `rotateY(${rotationAngle}deg)` }}
             >
               {/* 카드 타입에 따라 조건부 렌더링 */}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CardType } from "@/app/page";
 import Caption from "@/components/Caption";
+import ProgressBar from "@/components/ProgressBar";
 
 type Props = {
   cards: CardType[];
@@ -37,7 +38,7 @@ export default function Card({ cards, startIndex }: Props) {
   };
 
   return (
-    <div className="flex flex-col justify-center w-full h-full">
+    <div className="flex flex-col w-full h-full">
       <div
         className="flex justify-center items-end flex-grow [perspective:2000px]"
         onClick={handleFlip}
@@ -65,6 +66,7 @@ export default function Card({ cards, startIndex }: Props) {
         })}
       </div>
       <Caption cards={cards} currentIndex={currentIndex} />
+      <ProgressBar length={cards.length} currentIndex={currentIndex} />
     </div>
   );
 }

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { CardType } from "@/app/page";
+
+type Props = {
+  length: number; // Cards Array의 전체 length를 의미함
+  currentIndex: number;
+};
+
+export default function ProgressBar({ length, currentIndex }: Props) {
+  const totalBar = useRef<HTMLDivElement | null>(null);
+  const [segmentWidth, setSegmentWidth] = useState<number>(0);
+
+  const updateSegmentWidth = () => {
+    if (totalBar.current != null) {
+      setSegmentWidth(totalBar.current.offsetWidth / length);
+    }
+  };
+
+  useEffect(() => {
+    updateSegmentWidth();
+
+    window.addEventListener("resize", updateSegmentWidth);
+
+    return () => {
+      window.removeEventListener("resize", updateSegmentWidth);
+    };
+  });
+
+  console.log(segmentWidth);
+
+  return (
+    <div className="flex justify-center items-start">
+      <div
+        className="h-2 bg-slate-100 border-none mt-4 mb-10 w-3/4vh"
+        ref={totalBar}
+      >
+        <div
+          className="relative bg-black h-2 border-none transform transition-transform duration-1000 ease-in-out"
+          style={{
+            width: segmentWidth,
+            transform: `translateX(${segmentWidth * currentIndex}px)`,
+          }}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useEffect, useState } from "react";
-import { CardType } from "@/app/page";
 
 type Props = {
   length: number; // Cards Array의 전체 length를 의미함
@@ -27,8 +26,6 @@ export default function ProgressBar({ length, currentIndex }: Props) {
       window.removeEventListener("resize", updateSegmentWidth);
     };
   });
-
-  console.log(segmentWidth);
 
   return (
     <div className="flex justify-center items-start">

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -34,7 +34,7 @@ export default function ProgressBar({ length, currentIndex }: Props) {
         ref={totalBar}
       >
         <div
-          className="relative bg-black h-2 border-none transform transition-transform duration-1000 ease-in-out"
+          className="relative bg-black h-2 border-none transform transition-transform duration-1800 ease-in-out"
           style={{
             width: segmentWidth,
             transform: `translateX(${segmentWidth * currentIndex}px)`,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,11 @@ const config: Config = {
       fontFamily: {
         KoPub: ["KoPubWorldBatang", "serif"],
       },
+      transitionDuration: {
+        "1500": "1500ms",
+        "1800": "1800ms",
+        "2000": "2000ms",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
# 구현 내용
- carousel의 진행률을 확인할 수 있는 Progress Bar 구현
- 전체 Bar의 길이를 `useRef`로 받고, `useEffect`를 통해 resize 이벤트에 따라 길이 및 위치가 조정되게끔 구현

# TODO
- currentBar의 위치를 `translate` 속성으로 조절함에 따라, resize 시 일시적으로 currentBar가 전체 Bar를 벗어나는 경우 발생. 추후 리팩토링 예정.